### PR TITLE
Enable Makefile opts for MOUSEKEY and EXTRAKEY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ OPT_DEFS += -DBOOTLOADER_SIZE=4096
 #   comment out to disable the options.
 #
 #BOOTMAGIC_ENABLE ?= yes	# Virtual DIP switch configuration
-#MOUSEKEY_ENABLE ?= yes		# Mouse keys
-#EXTRAKEY_ENABLE ?= yes		# Audio control and System control
+MOUSEKEY_ENABLE ?= yes		# Mouse keys
+EXTRAKEY_ENABLE ?= yes		# Audio control and System control
 #CONSOLE_ENABLE ?= yes		# Console for debug
 #COMMAND_ENABLE ?= yes    	# Commands for debug and configuration
 NKRO_ENABLE ?= yes		# USB Nkey Rollover


### PR DESCRIPTION
I've tested these options, and am not seeing any downsides, and the mouse keys work MUCH better than 2 years ago. I figure that having them on by default could have saved a TMK newbie like me some time